### PR TITLE
fixed plot no show bug

### DIFF
--- a/pynita_source/metric_funs/metric_funs.py
+++ b/pynita_source/metric_funs/metric_funs.py
@@ -234,6 +234,7 @@ def plotMI(MI_2d, title, label):
     plt.colorbar(mappable, label=label)
     plt.suptitle(title)
     plt.tight_layout()
+    plt.show()
 
 #%%          
 def MI_complexity(results_dics):

--- a/pynita_source/nita.py
+++ b/pynita_source/nita.py
@@ -116,6 +116,7 @@ class nitaObj:
             fig, ax = plt.subplots(nrows=subplots_nrow, ncols=subplots_ncol)
             ax = np.array(ax)
             plt.tight_layout()
+            plt.show()
         
         for OBJECTID in OBJECTIDs:
             


### PR DESCRIPTION
Fixed plot no show for command line terminal, for some reason plots were visible in the spyder terminal, might have to do with spyder configuration for the matplotlib backend.